### PR TITLE
Maven hosting for plugin artifact

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -11,11 +11,14 @@ buildscript {
     }
 }
 
-allprojects {
-    repositories {
-        google()
-        jcenter()
-    }
+subprojects {
+  group = GROUP
+  version = VERSION_NAME
+
+  repositories {
+    google()
+    jcenter()
+  }
 }
 
 task clean(type: Delete) {

--- a/plugin/gradle.properties
+++ b/plugin/gradle.properties
@@ -1,10 +1,21 @@
-# Project-wide Gradle settings.
+GROUP=com.snap.daggerbrowser
+VERSION_NAME=0.7-SNAPSHOT
 
-# Specifies the JVM arguments used for the daemon process.
-# The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx1536m
+POM_DESCRIPTION=DaggerBrowser
 
-# When configured, Gradle will run in incubating parallel mode.
-# This option should only be used with decoupled projects. More details, visit
-# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
+POM_URL=http://github.com/snapchat/dagger-browser/
+POM_SCM_URL=http://github.com/snapchat/dagger-browser/
+POM_SCM_CONNECTION=scm:git:https://github.com/Snapchat/dagger-browser.git
+POM_SCM_DEV_CONNECTION=scm:git:git@github.com/Snapchat/dagger-browser.git
+
+POM_LICENCE_NAME=BSD 3-Clause "New" or "Revised" License
+POM_LICENCE_URL=https://opensource.org/licenses/BSD-3-Clause
+POM_LICENCE_DIST=repo
+
+POM_DEVELOPER_ID=snap
+POM_DEVELOPER_NAME=Snap, Inc.
+
+#Gradle properties: https://docs.gradle.org/current/userguide/build_environment.html
+org.gradle.caching=true
+org.gradle.configureondemand=true
+org.gradle.parallel=true

--- a/plugin/gradle/gradle-mvn-push.gradle
+++ b/plugin/gradle/gradle-mvn-push.gradle
@@ -1,0 +1,137 @@
+apply plugin: 'maven'
+apply plugin: 'signing'
+
+def isReleaseBuild() {
+    return VERSION_NAME.contains("SNAPSHOT") == false
+}
+
+def getReleaseRepositoryUrl() {
+  return hasProperty('RELEASE_REPOSITORY_URL') ? RELEASE_REPOSITORY_URL
+      : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+}
+
+def getSnapshotRepositoryUrl() {
+  return hasProperty('SNAPSHOT_REPOSITORY_URL') ? SNAPSHOT_REPOSITORY_URL
+      : "https://oss.sonatype.org/content/repositories/snapshots/"
+}
+
+def getRepositoryUsername() {
+    return hasProperty('SONATYPE_NEXUS_USERNAME') ? SONATYPE_NEXUS_USERNAME : ""
+}
+
+def getRepositoryPassword() {
+    return hasProperty('SONATYPE_NEXUS_PASSWORD') ? SONATYPE_NEXUS_PASSWORD : ""
+}
+
+afterEvaluate { project ->
+    uploadArchives {
+        repositories {
+            mavenDeployer {
+                beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+
+                pom.groupId = GROUP
+                pom.artifactId = POM_ARTIFACT_ID
+                pom.version = VERSION_NAME
+
+                repository(url: getReleaseRepositoryUrl()) {
+                    authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
+                }
+                snapshotRepository(url: getSnapshotRepositoryUrl()) {
+                    authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
+                }
+
+                pom.project {
+                    name POM_NAME
+                    packaging POM_PACKAGING
+                    description POM_DESCRIPTION
+                    url POM_URL
+
+                    scm {
+                        url POM_SCM_URL
+                        connection POM_SCM_CONNECTION
+                        developerConnection POM_SCM_DEV_CONNECTION
+                    }
+
+                    licenses {
+                        license {
+                            name POM_LICENCE_NAME
+                            url POM_LICENCE_URL
+                            distribution POM_LICENCE_DIST
+                        }
+                    }
+
+                    developers {
+                        developer {
+                            id POM_DEVELOPER_ID
+                            name POM_DEVELOPER_NAME
+                        }
+                    }
+                }
+
+            }
+        }
+    }
+
+    signing {
+        required { isReleaseBuild() && gradle.taskGraph.hasTask("uploadArchives") }
+        sign configurations.archives
+    }
+
+    def plugins = project.getPlugins()
+    if (plugins.hasPlugin('com.android.application') || plugins.hasPlugin('com.android.library')) {
+      task androidJavadocs(type: Javadoc) {
+        source = android.sourceSets.main.java.srcDirs
+        // TODO Update to include KT files OR stop publishing javadoc artifacts.
+        exclude "**/*.kt"
+        exclude "**/internal/**"
+        classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+
+        // Append also the classpath and files for release library variants.
+        // This fixes the javadoc warnings.
+        // Copy pasta from https://github.com/novoda/bintray-release/pull/39/files
+        def releaseVariant = project.android.libraryVariants.find { it.name.endsWith("release") }
+
+        classpath += releaseVariant.javaCompile.classpath
+        classpath += releaseVariant.javaCompile.outputs.files
+      }
+
+      task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
+        classifier = 'javadoc'
+        from androidJavadocs.destinationDir
+      }
+
+      task androidSourcesJar(type: Jar) {
+        classifier = 'sources'
+        from android.sourceSets.main.java.source
+      }
+
+      artifacts {
+        archives androidSourcesJar
+        archives androidJavadocsJar
+      }
+    }
+    else {
+      task sourcesJar(type: Jar, dependsOn: classes) {
+        classifier = 'sources'
+        from sourceSets.main.allSource
+      }
+
+      task javadocsJar(type: Jar, dependsOn: javadoc) {
+        classifier = 'javadoc'
+        from javadoc.destinationDir
+      }
+
+      artifacts {
+        archives sourcesJar
+        archives javadocsJar
+      }
+    }
+
+    if (JavaVersion.current().isJava8Compatible()) {
+      allprojects {
+        tasks.withType(Javadoc) {
+          options.addStringOption('Xdoclint:none', '-quiet')
+        }
+      }
+    }
+}

--- a/plugin/lib/build.gradle
+++ b/plugin/lib/build.gradle
@@ -36,3 +36,5 @@ compileTestKotlin {
         jvmTarget = "1.8"
     }
 }
+
+apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/plugin/lib/gradle.properties
+++ b/plugin/lib/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=daggerbrowser-processor
+POM_NAME=Dagger Browser Processor
+POM_PACKAGING=jar


### PR DESCRIPTION
We'd like users to be able to use the processor plugin via a hosted binary. Set up the scaffolding to deploy to Sonatype.