### PR TITLE
Support drag-and-drop loading of ComponentsManifest.json

### DIFF
--- a/browser/package.json
+++ b/browser/package.json
@@ -18,6 +18,7 @@
     "react": "^16.10.2",
     "react-autosuggest": "^9.4.3",
     "react-dom": "^16.10.2",
+    "react-dropzone": "^10.2.1",
     "react-materialize": "^3.5.8",
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.2.0",

--- a/browser/src/App.tsx
+++ b/browser/src/App.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React from 'react'
 import DaggerBrowser from "./components/GraphBrowser";
 import GraphBrowserLoader from "./components/GraphBrowserLoader";
 import { Route, HashRouter } from "react-router-dom";
@@ -7,11 +7,13 @@ import { QueryParamProvider } from "use-query-params";
 import { Paths } from "./Routes";
 import WeightServiceManager from "./service/WeightServiceManager";
 import { BrowserHeader } from "./components/BrowserHeader";
+import FileDropzone from "./components/FileDropzone";
 import Config from "./models/Config";
 
 interface AppState {
-  manifestUrl: string;
-  loadedUrl?: string;
+  manifestUrl?: string;
+  manifestFile?: File
+  loadedManifest: boolean;
   weightServiceManager?: WeightServiceManager
 }
 
@@ -21,7 +23,8 @@ class App extends React.Component<any, AppState> {
   constructor(props: any) {
     super(props);
     this.state = {
-      manifestUrl: Config.COMPONENTS_MANIFEST_JSON_URL
+      manifestUrl: Config.COMPONENTS_MANIFEST_JSON_URL,
+      loadedManifest: false
     };
   }
 
@@ -34,19 +37,45 @@ class App extends React.Component<any, AppState> {
   }
 
   async refresh() {
-    if (this.state.manifestUrl != this.state.loadedUrl) {
-      const success = await this.graphManager.load(this.state.manifestUrl);
-      this.setState({
-        weightServiceManager: success ? new WeightServiceManager(this.graphManager) : undefined,
-        loadedUrl: this.state.manifestUrl
-      })      
+    if (!this.state.loadedManifest) {
+      if (this.state.manifestFile) {
+        const success = await this.graphManager.loadFile(this.state.manifestFile);
+        this.setState({
+          weightServiceManager: success ? new WeightServiceManager(this.graphManager) : undefined,
+          loadedManifest: true
+        }) 
+      } else if (this.state.manifestUrl) {
+        const success = await this.graphManager.loadUrl(this.state.manifestUrl);
+        this.setState({
+          weightServiceManager: success ? new WeightServiceManager(this.graphManager) : undefined,
+          loadedManifest: true
+        })      
+      }
     }
   }
 
   private onChangeManifestUrl(url: string) {
     this.setState({
       manifestUrl: url,
-      loadedUrl: undefined
+      loadedManifest: false
+    })
+  }
+
+  private onChangeManifestFile(acceptedFiles: File[]) {
+    if (acceptedFiles.length != 1) {
+      alert("Upload a single ComponentsManifest.json")
+      return
+    }
+
+    const file = acceptedFiles[0]
+    if (file.type != "application/json") {
+      alert("Manifest must be a json file")
+      return
+    }
+
+    this.setState({
+      manifestFile: file,
+      loadedManifest: false
     })
   }
 
@@ -56,23 +85,26 @@ class App extends React.Component<any, AppState> {
         <Route  
           path={Paths.Home}
           render={props => (
-            <div>
-              <BrowserHeader manifestUrl={this.graphManager.manifestUrl} onChangeManifestUrl={(url) => this.onChangeManifestUrl(url)} />
-              {this.state.weightServiceManager ? (
-                <DaggerBrowser
-                  componentName={props.match.params.component ? decodeURIComponent(props.match.params.component) : ""}
-                  graphManager={this.graphManager}
-                  weightServiceManager={this.state.weightServiceManager}
-                />
-              ) : (
-                <GraphBrowserLoader loaded={this.state.loadedUrl != undefined} onChangeManifestUrl={(url) => this.onChangeManifestUrl(url)} />
-              )}
-            </div>
+              <FileDropzone onFilesSelected={(files) => this.onChangeManifestFile(files)}>
+                <div>
+                  <BrowserHeader manifestUrl={this.graphManager.manifestUrl} onChangeManifestUrl={(url) => this.onChangeManifestUrl(url)} />
+                  {this.state.weightServiceManager ? (
+                    <DaggerBrowser
+                      componentName={props.match.params.component ? decodeURIComponent(props.match.params.component) : ""}
+                      graphManager={this.graphManager}
+                      weightServiceManager={this.state.weightServiceManager}
+                    />
+                  ) : (
+                      <GraphBrowserLoader loaded={this.state.loadedManifest} onChangeManifestUrl={(url) => this.onChangeManifestUrl(url)} />
+                    )}
+                </div>
+            </FileDropzone>
           )}
         />
       </QueryParamProvider>
     </HashRouter>;
   }
 }
+
 
 export default App;

--- a/browser/src/App.tsx
+++ b/browser/src/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React from "react"
 import DaggerBrowser from "./components/GraphBrowser";
 import GraphBrowserLoader from "./components/GraphBrowserLoader";
 import { Route, HashRouter } from "react-router-dom";
@@ -62,7 +62,7 @@ class App extends React.Component<any, AppState> {
   }
 
   private onChangeManifestFile(acceptedFiles: File[]) {
-    if (acceptedFiles.length != 1) {
+    if (acceptedFiles.length !== 1) {
       alert("Upload a single ComponentsManifest.json")
       return
     }

--- a/browser/src/components/BrowserHeader.tsx
+++ b/browser/src/components/BrowserHeader.tsx
@@ -4,7 +4,6 @@ import Routes from "../Routes";
 import { LoadManifestModal } from "./LoadManifestModal";
 import React, { useRef } from "react";
 import {Navbar, Icon, NavItem, Dropdown, Divider, Modal, Button} from "react-materialize";
-import WeightServiceManager from "../service/WeightServiceManager";
 
 export interface Props {
   manifestUrl?: string;

--- a/browser/src/components/FileDropzone.tsx
+++ b/browser/src/components/FileDropzone.tsx
@@ -11,16 +11,16 @@ const FileDropzone: FunctionComponent<Props> = ({ manifestUrl, onFilesSelected, 
     const onDrop = useCallback(onFilesSelected, [])
     const { getRootProps, getInputProps, isDragActive } = useDropzone({ onDrop })
 
-    console.log("RENDER THE BLllOCK")
-
     return (
         <div {...getRootProps()}>
-            <input {...getInputProps()} />
+            {/* <input {...getInputProps()} /> */}
             {
                 isDragActive ?
                     (<div>
-                        <p>Drop to load manifest...</p>
                         {children}
+                        <div className="full-screen-alert">
+                            <p>Drop to load manifest...</p>
+                        </div>
                     </div>
                     ) :
 

--- a/browser/src/components/FileDropzone.tsx
+++ b/browser/src/components/FileDropzone.tsx
@@ -13,7 +13,6 @@ const FileDropzone: FunctionComponent<Props> = ({ manifestUrl, onFilesSelected, 
 
     return (
         <div {...getRootProps()}>
-            {/* <input {...getInputProps()} /> */}
             {
                 isDragActive ?
                     (<div>

--- a/browser/src/components/FileDropzone.tsx
+++ b/browser/src/components/FileDropzone.tsx
@@ -1,0 +1,33 @@
+import React, { useCallback, FunctionComponent } from 'react'
+import { useDropzone } from 'react-dropzone'
+
+
+type Props = {
+    manifestUrl?: string;
+    onFilesSelected: (files: File[]) => void
+}
+
+const FileDropzone: FunctionComponent<Props> = ({ manifestUrl, onFilesSelected, children }) => {
+    const onDrop = useCallback(onFilesSelected, [])
+    const { getRootProps, getInputProps, isDragActive } = useDropzone({ onDrop })
+
+    console.log("RENDER THE BLllOCK")
+
+    return (
+        <div {...getRootProps()}>
+            <input {...getInputProps()} />
+            {
+                isDragActive ?
+                    (<div>
+                        <p>Drop to load manifest...</p>
+                        {children}
+                    </div>
+                    ) :
+
+                    children
+            }
+        </div>
+    )
+}
+
+export default FileDropzone

--- a/browser/src/index.css
+++ b/browser/src/index.css
@@ -130,3 +130,16 @@ code {
   font-size: 24px;
   font-weight: 300;  
 }
+
+.full-screen-alert {
+  position:absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  padding-top: 10px;
+  padding-left: 50px;
+  background-color: #ee6e73;
+  font-size:  30px;
+  color: white;
+}

--- a/browser/src/models/GraphManager.tsx
+++ b/browser/src/models/GraphManager.tsx
@@ -29,7 +29,7 @@ export default class GraphManager {
     [componentName: string]: { [key: string]: Node[] };
   } = {};
 
-  async load(manifestUrl: string): Promise<boolean> {
+  async loadUrl(manifestUrl: string): Promise<boolean> {
     let classInfoUrl = manifestUrl.substring(0, manifestUrl.lastIndexOf("\/") + 1) + "ClassInfo.json";    
 
     try {
@@ -49,6 +49,29 @@ export default class GraphManager {
     this.manifestUrl = manifestUrl;
     this.classInfoUrl = classInfoUrl;
     return true;
+  }
+  
+  async loadFile(manifestFile: File): Promise<boolean> {
+    let manifestResponse = await this.readFileAsync(manifestFile)
+    console.log("WE READ")
+    console.log(manifestResponse)
+    this.componentSet = JSON.parse(manifestResponse) as ComponentSet;
+    this.populateCaches();
+    return true;
+  }
+
+  async readFileAsync(file: File): Promise<string> {
+    return new Promise((resolve, reject) => {
+      let reader = new FileReader();
+
+      reader.onload = () => {
+        resolve(reader.result as string);
+      };
+
+      reader.onerror = reject;
+
+      reader.readAsText(file);
+    })
   }
 
   getMatches(

--- a/browser/src/models/GraphManager.tsx
+++ b/browser/src/models/GraphManager.tsx
@@ -60,7 +60,7 @@ export default class GraphManager {
 
   async readFileAsync(file: File): Promise<string> {
     return new Promise((resolve, reject) => {
-      let reader = new FileReader();
+      const reader = new FileReader();
       reader.onload = () => {
         resolve(reader.result as string);
       };

--- a/browser/src/models/GraphManager.tsx
+++ b/browser/src/models/GraphManager.tsx
@@ -53,8 +53,6 @@ export default class GraphManager {
   
   async loadFile(manifestFile: File): Promise<boolean> {
     let manifestResponse = await this.readFileAsync(manifestFile)
-    console.log("WE READ")
-    console.log(manifestResponse)
     this.componentSet = JSON.parse(manifestResponse) as ComponentSet;
     this.populateCaches();
     return true;
@@ -63,13 +61,11 @@ export default class GraphManager {
   async readFileAsync(file: File): Promise<string> {
     return new Promise((resolve, reject) => {
       let reader = new FileReader();
-
       reader.onload = () => {
         resolve(reader.result as string);
       };
 
       reader.onerror = reject;
-
       reader.readAsText(file);
     })
   }


### PR DESCRIPTION
Working to reduce the overhead of trying a Dagger Browser instance with real data.

Add support for drag-and-drop of a ComponentsManifest.json to a Dagger Browser instance. Target use-case is loading a public instance of Dagger Browser and dropping in a generated manifest file.