### PR TITLE
Script to pull ComponentsManifest.json file

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -21,32 +21,8 @@ main() {
     fi
 
     echo "Looking for component graph files in $build_dir"
-
-    local components_manifest_file="build/ComponentsManifest.json"
-    mkdir -p build
-    local tmp="${components_manifest_file}.tmp"
-    find $build_dir -path '*/build/*_graph.json' >"$tmp"
-    echo '{"components": [' >|"$components_manifest_file"
-    for f in $(awk "NR != $(wc -l <$tmp)" $tmp); do
-        cat "$f" >>"$components_manifest_file"
-        echo ',' >>"$components_manifest_file"
-    done
-    f=$(tail -n 1 "$tmp")
-
-    if [ -z "$f" ]; then
-        echo "Failed to find any component graph files in $build_dir. Did you add the SPI plugin to your modules?"
-        exit 1
-    fi
-
-    cat "$f" >>"$components_manifest_file"
-    echo ']}' >>"$components_manifest_file"
-    
-    # clean up the tmp file
-    rm -f -- "$tmp"
-
-    # Copy the manifest 
-    cp -fR $components_manifest_file browser/public/$MANIFEST_FILENAME
-
+    `./scripts/mkmanifest.sh browser/public/$MANIFEST_FILENAME`
+ 
     # TODO: Generate the class info file
     local class_info_file="build/ClassInfo.json"
     echo '{}' >|"$class_info_file"

--- a/init.sh
+++ b/init.sh
@@ -20,8 +20,8 @@ main() {
         build_dir=plugin/sample/build
     fi
 
-    echo "Looking for component graph files in $build_dir"
-    `./scripts/mkmanifest.sh browser/public/$MANIFEST_FILENAME`
+    # Build ComponentstManifest.json
+    ./scripts/mkmanifest.sh $build_dir  browser/public/$MANIFEST_FILENAME
  
     # TODO: Generate the class info file
     local class_info_file="build/ClassInfo.json"
@@ -36,7 +36,9 @@ main() {
     pushd browser
     npm install
     popd
-    echo "Init completed."
+
+    echo "Init completed. Run a Browser:"
+    echo "    cd browser; npm run start"
 }
 
 main $@

--- a/run.sh
+++ b/run.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-# Initializes and runs the dagger browser given the build directory of project of where to search for 
-# component graph files. If the build directory is not provided, the sample will be compiled and used an example.
-# Usage: ./run.sh [build_dir]
-
-./init.sh $@
-
-cd browser && npm run start

--- a/scripts/mkmanifest.sh
+++ b/scripts/mkmanifest.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Initializes the dagger browser given the build directory of project of where to search for component graph files.
+# If the build directory is not provided, the sample will be compiled and used an example.
+# Usage: ./init.sh build_dir [out_file]
+
+set -eu
+
+MANIFEST_FILENAME=ComponentsManifest.json
+CLASSINFO_FILENAME=ClassInfo.json
+
+main() {
+    local build_dir=${1:-}
+    local out_file=${2:-}
+
+    # if component manifest is not provided, then we build the sample
+    if [ -z ${build_dir:-} ]; then
+        echo "Usage: $0 build_dir"
+        exit 1
+    fi
+
+    if [ -z ${out_file:-} ]; then
+        out_file="ComponentsManifest.json"
+    fi
+
+    echo "Looking for component graph files in $build_dir"
+
+    local components_manifest_file=$out_file
+    mkdir -p build
+    local tmp="${components_manifest_file}.tmp"
+    find $build_dir -path '*/build/*_graph.json' >"$tmp"
+    echo '{"components": [' >|"$components_manifest_file"
+    for f in $(awk "NR != $(wc -l <$tmp)" $tmp); do
+        cat "$f" >>"$components_manifest_file"
+        echo ',' >>"$components_manifest_file"
+    done
+    f=$(tail -n 1 "$tmp")
+
+    if [ -z "$f" ]; then
+        echo "Failed to find any component graph files in $build_dir. Did you add the SPI plugin to your modules?"
+        exit 1
+    fi
+
+    cat "$f" >>"$components_manifest_file"
+    echo ']}' >>"$components_manifest_file"
+    
+    # clean up the tmp file
+    rm -f -- "$tmp"
+
+    echo ""
+    echo "Generated $out_file"
+    echo ""
+}
+
+main $@

--- a/scripts/mkmanifest.sh
+++ b/scripts/mkmanifest.sh
@@ -18,7 +18,9 @@ main() {
         exit 1
     fi
 
-    if [ -z ${out_file:-} ]; then
+    if [ -d "$out_file" ]; then
+        out_file="${out_file}/ComponentsManifest.json"
+    elif [ -z ${out_file:-} ]; then
         out_file="ComponentsManifest.json"
     fi
 


### PR DESCRIPTION
Now that we can drag-and-drop a manifest file to a Dagger Browser instance, we should make it easy to generate the manifest file. Extract manifest file creation to its own script.