### PR TITLE
Fix class memory for components

### DIFF
--- a/browser/src/service/ClassSizeService.tsx
+++ b/browser/src/service/ClassSizeService.tsx
@@ -17,7 +17,7 @@ export default class ClassSizeService implements WeightService {
   }
 
   getWeight(componentName: string, node?: string): Weight | undefined {
-    const classSize = node ? this.getClassSize(node) : 0;
+    const classSize = this.getClassSize(node ? node : componentName);
     if (classSize) {
       var memorySizeKb = classSize.getMemorySize() / 1024;
       if (memorySizeKb > 1) {


### PR DESCRIPTION
By convention, we always pass components and their nodes in order to calculate class memory. However components by themselves (i.e. node is null) are also classes for which we should compute the memory.