### PR TITLE
Use variable when naming output file

### DIFF
--- a/scripts/mkmanifest.sh
+++ b/scripts/mkmanifest.sh
@@ -20,7 +20,7 @@ main() {
     if [ -d "$out_file" ]; then
         out_file="${out_file}/${MANIFEST_FILENAME}"
     elif [ -z ${out_file:-} ]; then
-        out_file=MANIFEST_FILENAME
+        out_file="$MANIFEST_FILENAME"
     fi
 
     echo "Looking for component graph files in $build_dir"


### PR DESCRIPTION
Made a small correction to `scripts/mkmanifest.sh`. When the script was run with one argument the manifest file was named `MANIFEST_FILENAME`. With this change, the file will be named `ComponentsManifest.json`, which I think was the intended outcome.