### PR TITLE
show the components that can provide a dependency

### DIFF
--- a/browser/src/components/ComponentSummary.tsx
+++ b/browser/src/components/ComponentSummary.tsx
@@ -28,6 +28,8 @@ const ComponentSummary = ({ graphManager, weightService, componentName, onSelect
         binding.kind === "MEMBERS_INJECTION"
     );
 
+  const componentProvisions = graph.nodes[0].dependencies
+
   const multiBindings = graph.nodes.filter(
     binding =>
       binding.kind === "MULTIBOUND_SET" || binding.kind === "MULTIBOUND_MAP"
@@ -54,6 +56,19 @@ const ComponentSummary = ({ graphManager, weightService, componentName, onSelect
             weight={weightService.getWeight(componentName)}
           />
         </div>
+
+        {componentProvisions.length > 0 && 
+          <div>Component Provisions:
+          {componentProvisions.map(binding =>
+            <NodeLink
+              key={binding.key}
+              scoped={true}
+              node={binding}
+              onSelect={node => onSelect(componentName, node)}
+            />
+          )}
+          </div>
+        }
 
         {membersInjectors.length > 0 &&
           <div>

--- a/browser/src/components/NodeSummary.tsx
+++ b/browser/src/components/NodeSummary.tsx
@@ -48,6 +48,15 @@ function readableKind(kind: String) {
   return kind
 }
 
+function getProvidingComponents(graphManager: GraphManager, componentName: string, node: Node): string {
+  var components = graphManager.getDependencyProviders(node.key)
+  if (components === undefined) {
+    return ""
+  }
+
+  return " (" + components.map(t => t.substring(1 + t.lastIndexOf('.'))).join() + ")"
+}
+
 function createdComponent(graphManager: GraphManager, componentName: string, node: Node) {
   if (!node.adjacentNodes) {
     return ""
@@ -83,6 +92,7 @@ export function NodeSummary({ graphManager, weightService, componentName, nodeNa
   const componentSimpleName = componentName.substring(componentName.lastIndexOf('.') + 1)
   const simpleScope = node.scope && node.scope.substring(node.scope.lastIndexOf('.') + 1)
   const createdComponentKey: string = createdComponent(graphManager, componentName ,node);
+  const providingComponents: string = getProvidingComponents(graphManager, componentName ,node);
 
   return (
     <div className="card">
@@ -129,6 +139,7 @@ export function NodeSummary({ graphManager, weightService, componentName, nodeNa
         <p>
           <span>Type: </span>
           {bindingKind}
+          {providingComponents}
           {createdComponentKey && 
             <span className="unselectable"> | &nbsp;
             <Link

--- a/browser/src/components/NodeSummary.tsx
+++ b/browser/src/components/NodeSummary.tsx
@@ -189,7 +189,7 @@ export function NodeSummary({ graphManager, weightService, componentName, nodeNa
 
         {node.kind == "COMPONENT_PROVISION" && (
           <p>
-          <span className="unselectable">Available from: </span>
+          <span className="unselectable">Provided by: </span>
           {providingComponents}
         </p>
         )}

--- a/browser/src/components/NodeSummary.tsx
+++ b/browser/src/components/NodeSummary.tsx
@@ -61,7 +61,13 @@ function getProvidingComponents(graphManager: GraphManager, componentName: strin
         to={Routes.Component(t)}
       >{t.substring(1 + t.lastIndexOf('.'))}
       </Link>
-      </div>
+      &nbsp;|&nbsp;
+      <Link
+        className="soft-link"
+        to={Routes.GraphNode(t, node.key)}
+      >Implementation
+      </Link>
+    </div>
   )
 }
 

--- a/browser/src/components/NodeSummary.tsx
+++ b/browser/src/components/NodeSummary.tsx
@@ -48,13 +48,21 @@ function readableKind(kind: String) {
   return kind
 }
 
-function getProvidingComponents(graphManager: GraphManager, componentName: string, node: Node): string {
+function getProvidingComponents(graphManager: GraphManager, componentName: string, node: Node) {
   var components = graphManager.getDependencyProviders(node.key)
   if (components === undefined) {
-    return ""
+    return undefined
   }
 
-  return " (" + components.map(t => t.substring(1 + t.lastIndexOf('.'))).join() + ")"
+  return components.map(t => 
+    <div>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+      <Link
+        className="soft-link"
+        to={Routes.Component(t)}
+      >{t.substring(1 + t.lastIndexOf('.'))}
+      </Link>
+      </div>
+  )
 }
 
 function createdComponent(graphManager: GraphManager, componentName: string, node: Node) {
@@ -92,7 +100,7 @@ export function NodeSummary({ graphManager, weightService, componentName, nodeNa
   const componentSimpleName = componentName.substring(componentName.lastIndexOf('.') + 1)
   const simpleScope = node.scope && node.scope.substring(node.scope.lastIndexOf('.') + 1)
   const createdComponentKey: string = createdComponent(graphManager, componentName ,node);
-  const providingComponents: string = getProvidingComponents(graphManager, componentName ,node);
+  const providingComponents = getProvidingComponents(graphManager, componentName ,node);
 
   return (
     <div className="card">
@@ -139,7 +147,6 @@ export function NodeSummary({ graphManager, weightService, componentName, nodeNa
         <p>
           <span>Type: </span>
           {bindingKind}
-          {providingComponents}
           {createdComponentKey && 
             <span className="unselectable"> | &nbsp;
             <Link
@@ -179,6 +186,14 @@ export function NodeSummary({ graphManager, weightService, componentName, nodeNa
             )}
           </p>
         )}
+
+        {node.kind == "COMPONENT_PROVISION" && (
+          <p>
+          <span className="unselectable">Available from: </span>
+          {providingComponents}
+        </p>
+        )}
+
         <br />
         <h6>Dependencies
           &nbsp;|&nbsp;


### PR DESCRIPTION
If a dependency is taken via a component dependency, it's helpful to know which components can provide that dependency. Print the list of components that can provide a particular binding key. Also show all provisions exposed by a component on its summary page.