### PR TITLE
shortened node names and added a tooltip to show full name

### DIFF
--- a/browser/src/components/NodeAutosuggest.tsx
+++ b/browser/src/components/NodeAutosuggest.tsx
@@ -3,7 +3,8 @@ import GraphManager, { GraphMatchResult } from "../models/GraphManager";
 import Autosuggest from "react-autosuggest";
 import NodeWeight from "./NodeWeight";
 import WeightService from "../service/WeightService";
-
+import DisplayNameHelper from "../util/DisplayNameHelper";
+import "./NodeToolTip.css";
 const MAX_SUGGESTIONS = 40;
 
 interface Props {
@@ -29,7 +30,7 @@ function getSuggestions(
 const NodeAutosuggest = ({ graphManager, weightService, onSelect, componentName }: Props) => {
   const [query, setQuery] = useState("");
   const searchRef = useRef<Autosuggest<GraphMatchResult>>(null);
-
+  const displayNameHelper = new DisplayNameHelper()
   const suggestions = useMemo(
     () => getSuggestions(graphManager, componentName || "", query),
     [graphManager, componentName, query]
@@ -52,40 +53,43 @@ const NodeAutosuggest = ({ graphManager, weightService, onSelect, componentName 
   }, []);
 
   return (
-    <Autosuggest<GraphMatchResult>
-      ref={searchRef}
-      suggestions={suggestions}
-      onSuggestionsFetchRequested={() => {}}
-      onSuggestionsClearRequested={() => setQuery("")}
-      onSuggestionSelected={(_, data) => {
-        onSelect(data.suggestion.componentName, data.suggestion.node.key);
-      }}
-      getSuggestionValue={suggestion => suggestion.node.key}
-      // TODO: Replace with simple node
-      renderSuggestion={suggestion => (
-        <div>
-          <span className="light-text">
-            {suggestion.componentName
-              ? "[" + suggestion.componentName.split(".").pop() + "] "
-              : ""}
-          </span>
-          {suggestion.node.key}
-          <NodeWeight
-            weight={weightService.getWeight(
-              suggestion.componentName,
-              suggestion.node.key
-            )}
-          />
-        </div>
-      )}
-      inputProps={{
-        value: query,
-        placeholder: "Find dependencies",
-        onChange: (_, params) => {
-          setQuery(params.newValue);
-        }
-      }}
-    />
+      <Autosuggest<GraphMatchResult>
+        ref={searchRef}
+        suggestions={suggestions}
+        onSuggestionsFetchRequested={() => {}}
+        onSuggestionsClearRequested={() => setQuery("")}
+        onSuggestionSelected={(_, data) => {
+          onSelect(data.suggestion.componentName, data.suggestion.node.key);
+        }}
+        getSuggestionValue={suggestion => suggestion.node.key}
+        // TODO: Replace with simple node
+        renderSuggestion={suggestion => (
+          <div className = "tooltip_suggest">
+            <span className="light-text">
+              {suggestion.componentName
+                ? "[" + suggestion.componentName.split(".").pop() + "] "
+                : ""}
+            </span>
+            {displayNameHelper.displayNameForKey(suggestion.node.key)} &nbsp;
+            <div className="tooltiptext_suggest">
+              <span className="tooltiptext_suggest">{suggestion.node.key}</span>
+            </div>
+            <NodeWeight
+              weight={weightService.getWeight(
+                suggestion.componentName,
+                suggestion.node.key
+              )}
+            />
+          </div>
+        )}
+        inputProps={{
+          value: query,
+          placeholder: "Find dependencies",
+          onChange: (_, params) => {
+            setQuery(params.newValue);
+          }
+        }}
+      />
   );
 };
 

--- a/browser/src/components/NodeLink.tsx
+++ b/browser/src/components/NodeLink.tsx
@@ -1,8 +1,10 @@
-import React from "react";
+import React , { useState } from "react";
 import { Node, Weight } from "../models/Graph";
 import CodeLink from "./CodeLink";
 import NodeIcon from "./NodeIcon";
 import NodeWeight from "./NodeWeight";
+import DisplayNameHelper from "../util/DisplayNameHelper";
+import "./NodeToolTip.css";
 
 type Props = {
   node: Node;
@@ -28,15 +30,20 @@ const NodeLink: React.FC<Props> = ({
   kind
 }: Props) => {
   const scope = node.scope ? `[${node.scope.split(".").pop()}]` : "";
+  const displayNameHelper = new DisplayNameHelper()
+
   return (<div>
     <div
       className="binding"
       onClick={() => onSelect && onSelect(node.key)}
     >
-      <div className="text">
+      <div className="tooltip_link">
         <NodeIcon kind={kind || node.kind} />
         {scoped && <span className="light-text">{scope}&nbsp;</span>}
-        {getDisplayName(node.key)}&nbsp;
+        {displayNameHelper.displayNameForKey(getDisplayName(node.key))}&nbsp;
+        <div className="tooltiptext_link">
+              <span className="tooltiptext_link">{node.key}</span>
+        </div>
       </div>
       <div>
         <CodeLink link={node.key} />

--- a/browser/src/components/NodeToolTip.css
+++ b/browser/src/components/NodeToolTip.css
@@ -1,0 +1,39 @@
+.tooltip_suggest {
+    position: relative;
+    display: inline-block;
+}
+  
+.tooltip_suggest .tooltiptext_suggest {
+    visibility: hidden;
+    background-color: white;
+    color: black;
+    text-align: center;
+    border-radius: 6px;
+    padding: 8px 0;
+    position:fixed;
+    z-index: 1;
+}
+  
+.tooltip_suggest:hover .tooltiptext_suggest {
+    visibility: visible;
+}
+
+.tooltip_link {
+    position: relative;
+    display: inline-block;
+}
+  
+.tooltip_link .tooltiptext_link {
+    visibility: hidden;
+    background-color: white;
+    color: black;
+    text-align: center;
+    border-radius: 3px;
+    padding: 2px 0;
+    position:fixed;
+    z-index: 1;
+}
+  
+.tooltip_link:hover .tooltiptext_link {
+    visibility: visible;
+}


### PR DESCRIPTION
Background: When searching through the dagger-browser, it can be challenging to read because some nodes have large names. Making the names shorter will increase readability.

Change: Implementing the displayNameForKey() method in the NodeAutosuggest.tsx and the NodeLink.tsx file will help shorten the names of each node. Added a css file, NodeToolTip.css that will allow the full name to be displayed under the shortened name when hovering. 

TestPlan: Run the dagger-browser locally and test features if they work properly.