### PR TITLE
/search handling multiple components w/ same name

### DIFF
--- a/browser/src/__tests__/DisplayNameHelper.test.tsx
+++ b/browser/src/__tests__/DisplayNameHelper.test.tsx
@@ -15,34 +15,34 @@ describe("Various classes in the Dagger Graph, will return the correct shorter n
         "CoffeeApp.CoffeeShop")
     })
 
-    test('displayNameHelperShouldReturn_@DesignerNewsApi OkHttpClient', () => {
-      expect(displayNameHelper.displayNameForKey("@io.plaidapp.core.dagger.DesignerNewsApi okhttp3.OkHttpClient")).equals(
-        "@DesignerNewsApi OkHttpClient")
+    test('displayNameHelperShouldReturn_@DesignerNewsApi OkClient', () => {
+      expect(displayNameHelper.displayNameForKey("@io.plaidapp.core.dagger.DesignerNewsApi okhttp3.OkClient")).equals(
+        "@DesignerNewsApi OkClient")
     })
 
-    test('displayNameHelperShouldReturn_LoginLocalDataSource', () => {
-      expect(displayNameHelper.displayNameForKey("io.plaidapp.core.designernews.data.login.LoginLocalDataSource")).equals(
-        "LoginLocalDataSource"
+    test('displayNameHelperShouldReturn_Login', () => {
+      expect(displayNameHelper.displayNameForKey("com.snap.dagger.sample.data.login.Login")).equals(
+        "Login"
         )
     })
 
     test('displayNameHelperShouldReturn_Map<Class<? DurableJob<?>>, Provider<DurableJobProcessor<?,?>>>' + 
-    ' LensesDurableJobComponentMultibindingsModule', () => {
+    ' AuthorDetailsModule', () => {
       expect(displayNameHelper.displayNameForKey(
-        "java.util.Map<java.lang.Class<? extends com.snap.durablejob.DurableJob<?>>,javax.inject.Provider<"+
-        "com.snap.durablejob.DurableJobProcessor<?,?>>> com.snap.lenses.app.LensesDurableJobComponent_MultibindingsModule"+
-        "#provide_socialUnlockResponseCacheCleanupProcessorMultibinding")).equals(
-           "Map<Class<? DurableJob<?>>, Provider<DurableJobProcessor<?,?>>> LensesDurableJobComponentMultibindingsModule"
+        "java.util.Map<java.lang.Class<? extends com.snap.dagger.DurableJob<?>>,javax.inject.Provider<"+
+        "com.snap.dagger.DurableJobProcessor<?,?>>> com.snap.dagger.browser.AuthorDetailsModule"+
+        "#Multibinding")).equals(
+           "Map<Class<? DurableJob<?>>, Provider<DurableJobProcessor<?,?>>> AuthorDetailsModule"
           )
       })
     
-    test('displayNameHelperShouldReturn_SpectaclesModules.SpectaclesExportApiModule', () => {
-      expect(displayNameHelper.displayNameForKey("com.snap.spectacles.bindings.SpectaclesModules.SpectaclesExportApiModule")
-      ).equals("SpectaclesModules.SpectaclesExportApiModule")
+    test('displayNameHelperShouldReturn_CoffeeMachine.CoffeeMachine', () => {
+      expect(displayNameHelper.displayNameForKey("com.snap.dagger.browser.sample.CoffeeMachine.CoffeeMachine")
+      ).equals("CoffeeMachine.CoffeeMachine")
     })
 
-    test('displayNameHelperShouldReturn_LegacyMainActivitySubcomponent', () => {
-      expect(displayNameHelper.displayNameForKey("com.snap.mushroom.dagger.LegacyMainActivitySubcomponent")
-      ).equals("LegacyMainActivitySubcomponent")
+    test('displayNameHelperShouldReturn_CoffeeBeans', () => {
+      expect(displayNameHelper.displayNameForKey("com.snap.dagger.browser.sample.CoffeeBeans")
+      ).equals("CoffeeBeans")
     })
   });

--- a/browser/src/__tests__/DisplayNameHelper.test.tsx
+++ b/browser/src/__tests__/DisplayNameHelper.test.tsx
@@ -35,4 +35,14 @@ describe("Various classes in the Dagger Graph, will return the correct shorter n
            "Map<Class<? DurableJob<?>>, Provider<DurableJobProcessor<?,?>>> LensesDurableJobComponentMultibindingsModule"
           )
       })
+    
+    test('displayNameHelperShouldReturn_SpectaclesModules.SpectaclesExportApiModule', () => {
+      expect(displayNameHelper.displayNameForKey("com.snap.spectacles.bindings.SpectaclesModules.SpectaclesExportApiModule")
+      ).equals("SpectaclesModules.SpectaclesExportApiModule")
+    })
+
+    test('displayNameHelperShouldReturn_LegacyMainActivitySubcomponent', () => {
+      expect(displayNameHelper.displayNameForKey("com.snap.mushroom.dagger.LegacyMainActivitySubcomponent")
+      ).equals("LegacyMainActivitySubcomponent")
+    })
   });

--- a/browser/src/components/NodeSummary.tsx
+++ b/browser/src/components/NodeSummary.tsx
@@ -6,6 +6,8 @@ import Routes from "src/Routes";
 import { GraphSelector } from "./GraphSelector";
 import WeightService from "../service/WeightService";
 import { Node } from "src/models/Graph";
+import SubcomponentSummary from "./SubcomponentSummary";
+import DisplayNameHelper from "src/util/DisplayNameHelper";
 
 export type Props = {
   graphManager: GraphManager;
@@ -95,7 +97,7 @@ function createdComponent(graphManager: GraphManager, componentName: string, nod
 
 export function NodeSearch({ graphManager, weightService, nodeName }: SearchProps) {
   //search for the top five choices the nodeName could be in the Dagger-Graph based on the nodeName
-  var searchResult =  graphManager.getMatches( "", nodeName.trim().toLowerCase(), 1, false);
+  var searchResult =  graphManager.getMatches( "", nodeName.trim().toLowerCase(), 5, false);
   // return if nodeName is not found in the graph
   if (searchResult.length == 0) {
     return (
@@ -104,7 +106,26 @@ export function NodeSearch({ graphManager, weightService, nodeName }: SearchProp
       </div>
     )
   }
-  //TODO: add a component that handles multiple search results like "MemoryModule" 
+  /* If there are more than 1 possible Subcomponent, then the different parents will be displayed based
+     the number of bindings they each have
+  */
+  if (searchResult.length > 1) {
+    return (
+      <div>
+        {searchResult.map(element => {
+          let total = graphManager.getSubcomponentBindings(element.componentName, element.node.key)
+          if(total.length != 0){
+            return<SubcomponentSummary 
+              graphManager={graphManager} 
+              weightService={weightService} 
+              componentName={element.componentName} 
+              subcomponentName={element.node.key} 
+              />
+          }
+        })}
+      </div>
+    )
+  }
   var componentName = searchResult[0].componentName
   var nodeName: string = searchResult[0].node.key
   var prop: Props = {graphManager, weightService, componentName, nodeName}
@@ -113,6 +134,7 @@ export function NodeSearch({ graphManager, weightService, nodeName }: SearchProp
 
 export function NodeSummary({ graphManager, weightService, componentName, nodeName }: Props) {
   const history = useHistory();
+  const displayNameHelper = new DisplayNameHelper()
   const node = graphManager.getNode(componentName, nodeName);
 
   if (!node) {
@@ -169,7 +191,10 @@ export function NodeSummary({ graphManager, weightService, componentName, nodeNa
                 className="soft-link"
                 to={Routes.SubComponent(componentName, node.component)}
               >
-                {node.component}
+              <div className="tooltip_link">
+              {displayNameHelper.displayNameForKey(node.component)}
+                <span className="tooltiptext_link">{node.component}</span>
+              </div>
           </Link>
         </p>
         )}
@@ -209,7 +234,10 @@ export function NodeSummary({ graphManager, weightService, componentName, nodeNa
                 className="soft-link"
                 to={Routes.GraphModule(componentName, node.module)}
               >
-                {bindingModule}
+                <div className="tooltip_link">
+                  {displayNameHelper.displayNameForKey(bindingModule)}
+                  <span className="tooltiptext_link">{bindingModule}</span>
+              </div>
               </Link>
             ) : (
               <span>n/a</span>

--- a/browser/src/components/NodeSummary.tsx
+++ b/browser/src/components/NodeSummary.tsx
@@ -96,7 +96,7 @@ function createdComponent(graphManager: GraphManager, componentName: string, nod
 }
 
 export function NodeSearch({ graphManager, weightService, nodeName }: SearchProps) {
-  //search for the top five choices the nodeName could be in the Dagger-Graph based on the nodeName
+  //search for the top five choices the nodeName could be in the Graph based on the nodeName
   var searchResult =  graphManager.getMatches( "", nodeName.trim().toLowerCase(), 5, false);
   // return if nodeName is not found in the graph
   if (searchResult.length == 0) {

--- a/browser/src/components/NodeSummary.tsx
+++ b/browser/src/components/NodeSummary.tsx
@@ -110,6 +110,16 @@ export function NodeSearch({ graphManager, weightService, nodeName }: SearchProp
      the number of bindings they each have
   */
   if (searchResult.length > 1) {
+    //If nodeName equals to the shortName of a node key, return that node
+    const displayNameHelper = new DisplayNameHelper()
+    {searchResult.map(element => {
+        if(displayNameHelper.displayNameForKey(element.node.key) == nodeName){
+          var componentName = element.componentName
+          var subComponentName: string = element.node.key
+          var prop: Props = { graphManager, weightService, componentName, nodeName: subComponentName }
+          return NodeSummary(prop)
+        }
+    })}
     return (
       <div>
         {searchResult.map(element => {


### PR DESCRIPTION
Background: A graph can be large, meaning some subcomponent names are the same as others. However we can differentiate these with the component name. We've updated the /search/nodeName route to handle cases where there are multiple subcomponents with the same name.

Changes: We've added another condition that will handle cases where results there are multiple nodes with the same name. Displaying the ones that have the most bindings as priority. We've also added a few more unit test to ensure the displayNameHelper() returns the desired output. Used displayNameHelper() to shorten modules and subcomponents when displaying info about a particular node.

Test Plan: Run Dagger-Browser locally

<img width="1419" alt="Screen Shot 2021-11-09 at 10 40 34 AM" src="https://user-images.githubusercontent.com/89438827/140984939-9593eb0f-a209-4281-9707-03b77302cd8b.png">


In the image above, we have a case where the user searches for 'c' and each  node that contains the phrase 'c' will be displayed