### PR TITLE
Fix Search Result Display

### DIFF
--- a/browser/src/components/NodeSummary.tsx
+++ b/browser/src/components/NodeSummary.tsx
@@ -97,7 +97,7 @@ function createdComponent(graphManager: GraphManager, componentName: string, nod
 
 export function NodeSearch({ graphManager, weightService, nodeName }: SearchProps) {
   //search for the top five choices the nodeName could be in the Graph based on the nodeName
-  var searchResult =  graphManager.getMatches( "", nodeName.trim().toLowerCase(), 5, false);
+  var searchResult =  graphManager.getMatches( "", nodeName.trim().toLowerCase(), 1, false);
   // return if nodeName is not found in the graph
   if (searchResult.length == 0) {
     return (


### PR DESCRIPTION
**Background**

The search function seems not work with our internal graph. This PR force the search always return the top 1 result to stop bleeding.

**Change**

* Return only top 1 matching result for given nodeName

**Test Plan**

* Test with internal graph json file, make sure search page will re-direct to given node when nodeName is correct.