### PR TITLE
node search multi display

### DIFF
--- a/browser/src/components/GraphBrowser.tsx
+++ b/browser/src/components/GraphBrowser.tsx
@@ -125,6 +125,7 @@ export const GraphBrowser = ({ graphManager, weightServiceManager, componentName
                 weightService={weightService}
                 nodeName={decodeURIComponent(props.match.params.node as string)}
                 componentName={componentName}
+                fullDetails={true}
               />
             )}
           ></Route>

--- a/browser/src/components/NodeSummary.tsx
+++ b/browser/src/components/NodeSummary.tsx
@@ -160,7 +160,7 @@ export function NodeSummary({ graphManager, weightService, componentName, nodeNa
               node={node}
               weight={weightService.getWeight(componentName, node.key)}
               onSelect={() => 
-                {!fullDetails && history.push(Routes.GraphNode(componentName, node.key))}
+                history.push(Routes.GraphNode(componentName, node.key))
               }
               />
         </div>
@@ -254,7 +254,9 @@ export function NodeSummary({ graphManager, weightService, componentName, nodeNa
         )}
 
         <br />
-       {fullDetails && <h6>Dependencies
+  {fullDetails && 
+  <div> 
+        <h6>Dependencies
           &nbsp;|&nbsp;
           <Link
             className="soft-link"
@@ -262,8 +264,8 @@ export function NodeSummary({ graphManager, weightService, componentName, nodeNa
           >
           transitive
           </Link>
-        </h6>}
-        {fullDetails && node &&
+        </h6>
+        {node &&
           node.dependencies
             .map(d => ({
               node: graphManager.getNode(componentName, d.key),
@@ -284,10 +286,10 @@ export function NodeSummary({ graphManager, weightService, componentName, nodeNa
                 />
               );
             })}
-        {!node || (node.dependencies.length === 0 && <div>None</div>) && fullDetails}
+        {!node || (node.dependencies.length === 0 && <div>None</div>)}
         <br />
-        {fullDetails && <h6>Callsites</h6>}
-        {fullDetails && callsites.map(binding => {
+        <h6>Callsites</h6>
+        {callsites.map(binding => {
           return (
             <NodeLink
               key={binding.key}
@@ -298,7 +300,9 @@ export function NodeSummary({ graphManager, weightService, componentName, nodeNa
             />
           );
         })}
-        {fullDetails && callsites.length === 0 && <div>None</div>}
+        {callsites.length === 0 && <div>None</div>}
+        </div>
+        }
       </div>
     </div>
   );


### PR DESCRIPTION
Background: When subcomponents have multiple names we'd like to see them all and be able to choose the correct one we're searching for. 

Changes: When the results from the search route contain more than one component, will display a partial summary for each component to allow the user to select the right one.

Test Plan: Run project locally & test different cases

<img width="1256" alt="Screen Shot 2021-11-10 at 4 42 34 PM" src="https://user-images.githubusercontent.com/89438827/141216365-34ea879e-7e68-4d16-8d78-a68b5cceb60c.png">


