### PR TITLE
shortName = nodeName

### DIFF
--- a/browser/src/components/NodeSummary.tsx
+++ b/browser/src/components/NodeSummary.tsx
@@ -108,28 +108,30 @@ export function NodeSearch({ graphManager, weightService, nodeName }: SearchProp
       </div>
     )
   }
-  if (searchResult.length > 1 && shortNameEqualsNodeName(searchResult, nodeName)) {
+  if (searchResult.length > 1) {
     //return fullNode Summary if exactly 1 of the result nodes are equal to the short name of a node 
-    return (
-      <div>
-        {searchResult.map(element => {
-          if(displayNameHelper.displayNameForKey(element.node.key) == nodeName){
-            var prop : Props = {graphManager, weightService, componentName : element.componentName, nodeName : element.node.key, fullDetails: true}
+    if (shortNameEqualsNodeName(searchResult, nodeName)) {
+      return (
+        <div>
+          {searchResult.map(element => {
+            if(displayNameHelper.displayNameForKey(element.node.key) == nodeName){
+              var prop : Props = {graphManager, weightService, componentName : element.componentName, nodeName : element.node.key, fullDetails: true}
+              return NodeSummary(prop)
+            }
+          })}
+        </div>
+      )
+    } else {
+      // will partially display each nodes summary
+      return (
+        <div>
+          {searchResult.map(element => {
+            var prop : Props = {graphManager, weightService, componentName : element.componentName, nodeName : element.node.key, fullDetails: false}
             return NodeSummary(prop)
-          }
-        })}
-      </div>
-    )
-  } else if (searchResult.length > 1) {
-    // will partially display each nodes summary
-    return (
-      <div>
-        {searchResult.map(element => {
-          var prop : Props = {graphManager, weightService, componentName : element.componentName, nodeName : element.node.key, fullDetails: false}
-          return NodeSummary(prop)
-        })}
-      </div>
-    )
+          })}
+        </div>
+      )
+    }
   } else {
   //if searchResult is a length of 1, return the summary of the node
   var componentName = searchResult[0].componentName

--- a/browser/src/components/NodeSummary.tsx
+++ b/browser/src/components/NodeSummary.tsx
@@ -109,8 +109,8 @@ export function NodeSearch({ graphManager, weightService, nodeName }: SearchProp
     )
   }
   if (searchResult.length > 1) {
-    //return fullNode Summary if exactly 1 of the result nodes are equal to the short name of a node 
-    if (shortNameEqualsNodeName(searchResult, nodeName)) {
+    //return full node Summary if exactly 1 of the result nodes are equal to the short name of a node 
+    if (displayFullSummary(searchResult, nodeName)) {
       return (
         <div>
           {searchResult.map(element => {
@@ -141,17 +141,12 @@ export function NodeSearch({ graphManager, weightService, nodeName }: SearchProp
   }
 }
 
-function shortNameEqualsNodeName(searchResult: GraphMatchResult[], nodeName: string) : boolean {
+function displayFullSummary(searchResult: GraphMatchResult[], nodeName: string) : boolean {
   const displayNameHelper = new DisplayNameHelper()
-  //counts how many short names in the graph equals to nodeName 
-  var commonCount: number = 0
-  searchResult.map(element => {
-    if(displayNameHelper.displayNameForKey(element.node.key) == nodeName){
-      commonCount+=1
-    }
-  })
-  // return false if there are multiple short names equal to eachother or if no short name equal to the nodeName
-  if(commonCount > 1 || commonCount == 0){
+  //counts how many short names in the graph equal to the nodeName 
+  var commonCount = searchResult.filter(element => displayNameHelper.displayNameForKey(element.node.key) == nodeName);
+  // return false if there isn't a unique shortName equal to the nodeName
+  if (commonCount.length != 1) {
     return false
   }
   return true

--- a/browser/src/components/NodeSummary.tsx
+++ b/browser/src/components/NodeSummary.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import GraphManager from "../models/GraphManager";
+import GraphManager, { GraphMatchResult } from "../models/GraphManager";
 import { Link, useHistory } from "react-router-dom";
 import NodeLink from "./NodeLink";
 import Routes from "src/Routes";
@@ -108,13 +108,20 @@ export function NodeSearch({ graphManager, weightService, nodeName }: SearchProp
       </div>
     )
   }
-  // will partially display each nodes summary
-  if (searchResult.length > 1) {
-    {searchResult.map(element => {
-      if(displayNameHelper.displayNameForKey(element.node.key) == nodeName){
-        //TODO: If nodeName is CoffeeMaker && results list contains CoffeeMakerController & CoffeeMaker return CoffeeMaker
-      }
-    })}
+  if (searchResult.length > 1 && shortNameEqualsNodeName(searchResult, nodeName)) {
+    //return fullNode Summary if exactly 1 of the result nodes are equal to the short name of a node 
+    return (
+      <div>
+        {searchResult.map(element => {
+          if(displayNameHelper.displayNameForKey(element.node.key) == nodeName){
+            var prop : Props = {graphManager, weightService, componentName : element.componentName, nodeName : element.node.key, fullDetails: true}
+            return NodeSummary(prop)
+          }
+        })}
+      </div>
+    )
+  } else if (searchResult.length > 1) {
+    // will partially display each nodes summary
     return (
       <div>
         {searchResult.map(element => {
@@ -123,11 +130,29 @@ export function NodeSearch({ graphManager, weightService, nodeName }: SearchProp
         })}
       </div>
     )
-  }
+  } else {
+  //if searchResult is a length of 1, return the summary of the node
   var componentName = searchResult[0].componentName
   var nodeName: string = searchResult[0].node.key
   var prop: Props = {graphManager, weightService, componentName, nodeName, fullDetails : true}
   return NodeSummary(prop)
+  }
+}
+
+function shortNameEqualsNodeName(searchResult: GraphMatchResult[], nodeName: string) : boolean {
+  const displayNameHelper = new DisplayNameHelper()
+  //counts how many short names in the graph equals to nodeName 
+  var commonCount: number = 0
+  searchResult.map(element => {
+    if(displayNameHelper.displayNameForKey(element.node.key) == nodeName){
+      commonCount+=1
+    }
+  })
+  // return false if there are multiple short names equal to eachother or if no short name equal to the nodeName
+  if(commonCount > 1 || commonCount == 0){
+    return false
+  }
+  return true
 }
 
 export function NodeSummary({ graphManager, weightService, componentName, nodeName, fullDetails }: Props) {


### PR DESCRIPTION
Background: When using the search route if we search for a node in the graph we'd like to return the full node summary where the shortName is equal to the nodeName we're searching for. However we'll only do this if we find one match. If there are multiple components with the same shortName equal to nodeName then we must return multiple partial summaries for each node.

Changes: added method and conditions to verify the nodeName were searching for is equal to any shortName in the graph based on the description above.

TestPlan: Run dagger-browser locally & try different /search cases 